### PR TITLE
Add documentation for interaction and audio packages

### DIFF
--- a/packages/com.sonosthesia.arpeggiator/README.md
+++ b/packages/com.sonosthesia.arpeggiator/README.md
@@ -1,1 +1,15 @@
-Channel arpeggiator for the sonosthesia project. This package generalizes the concept of a MIDI note arpeggiator to any data type. An arpeggiator is itself a channel which takes a channel as input and generates modulated delayed copies of each input stream.
+# com.sonosthesia.arpeggiator
+
+Channel arpeggiators for the sonosthesia project. This package generalizes the concept of a MIDI arpeggiator to any data type: it listens to an incoming [channel](https://github.com/jbat100/sonosthesia-unity-packages/tree/main/packages/com.sonosthesia.channel), duplicates each stream and applies per-step modulation before re-emitting the stream as a new channel.
+
+## Modulation building blocks
+
+Modulators let you sculpt how values evolve across the arpeggio. Float, vector and colour modulators combine animation curves with randomization to create offsets for each step. Followers (for floats, colours and vectors) apply the modulation to a specific property so the generated streams inherit the desired behaviour without bespoke scripts.
+
+## Scheduling and termination
+
+`StaticArpeggiator` and `ScheduledArpeggiator` drive when new steps are emitted. Terminators such as `ArpeggiatorTimerTerminator` or `UnitArpeggiatorTerminator` control when each stream completes, ensuring downstream components see clean lifecycle events.
+
+## Integration points
+
+Arpeggiators use UniRx observables under the hood so they can sit anywhere a channel is expected. Components like `Aftertoucher` make it easy to modulate aftertouch-style data in response to arpeggiated steps, allowing expressive playback without tying code to a specific payload type.

--- a/packages/com.sonosthesia.deforminteraction/README.md
+++ b/packages/com.sonosthesia.deforminteraction/README.md
@@ -1,1 +1,11 @@
+# com.sonosthesia.deforminteraction
 
+Interaction-driven deformations that bridge [deform](https://github.com/jbat100/sonosthesia-unity-packages/tree/main/packages/com.sonosthesia.deform) meshes with the interaction framework. Affordance components react to touch or collision streams and drive noise controllers so meshes pulse, ripple or swell where the interaction occurs.
+
+## Mesh noise affordances
+
+`MeshNoiseAffordance` variants take a `CompoundNoiseMeshController` and a noise configuration and update them every frame while an interaction is active. Spatial falloff settings determine where the deformation originates (actor, source or world space) and how its intensity decays across the surface.
+
+## Envelope-driven parameters
+
+Displacement, radius and speed envelopes are evaluated over the lifetime of the interaction, allowing smooth attacks and releases. Each affordance tracks actor motion to update falloff handles and schedules release timing so the deformation fades out cleanly when the interaction ends.

--- a/packages/com.sonosthesia.fmod/README.md
+++ b/packages/com.sonosthesia.fmod/README.md
@@ -1,1 +1,15 @@
+# com.sonosthesia.fmod
 
+FMOD integration helpers for the sonosthesia project. The package wraps FMOD Studio components so they can participate in signal, channel and interaction graphs without bespoke glue code.
+
+## Playback and routing
+
+Utility components such as `FMODSound`, `FMODEventReferenceSound` and `FMODEmitter` provide simple ways to trigger events while exposing parameters that can be driven by signals. Mixer utilities (`VCAVolume`, `BusVolume`, `Volume`) make it easy to alter buses or VCAs at runtime and keep levels in sync with other audio sources.
+
+## Processing
+
+`FMODProcessor` and `FMODDSPProcessor` offer a lifecycle-aware hook into FMOD channel groups. They let you attach processors to live channel groups, configure DSP behaviour, and cleanly tear down the processing pipeline when sources stop.
+
+## Debugging and testing
+
+Test helpers like `FMODCoreTest`, `FMODInstanceDebug` and `FMODTrackVolume` make it straightforward to validate event routing and runtime parameter changes inside Unity scenes.

--- a/packages/com.sonosthesia.fmodinteraction/README.md
+++ b/packages/com.sonosthesia.fmodinteraction/README.md
@@ -1,1 +1,11 @@
+# com.sonosthesia.fmodinteraction
 
+Interaction affordances that drive FMOD emitters. The package connects the [touch](https://github.com/jbat100/sonosthesia-unity-packages/tree/main/packages/com.sonosthesia.touch) and [collide](https://github.com/jbat100/sonosthesia-unity-packages/tree/main/packages/com.sonosthesia.collide) interaction streams to FMOD events so spatial input can trigger audio in a controlled way.
+
+## Configurable emitters
+
+`FMODEmitterConfiguration` assets capture the event reference, parameters and spatial behaviour required for playback. Specialised configurations for touch and collision let you author different responses for pointer-based input versus physics events.
+
+## Play and parameter affordances
+
+`FMODPlayAffordance` components launch or stop events when an interaction begins or ends. `FMODEmitterAffordance` variants expose Unity events for custom bindings, while `CollideFMODEmitterAffordance` and `TouchFMODEmitterAffordance` provide ready-made hooks for common interaction types.

--- a/packages/com.sonosthesia.packaudio/README.md
+++ b/packages/com.sonosthesia.packaudio/README.md
@@ -1,1 +1,11 @@
+# com.sonosthesia.packaudio
 
+Pack (MessagePack) audio helpers for the sonosthesia project. The package mirrors the audio analysis data used by [pack](https://github.com/jbat100/sonosthesia-unity-packages/tree/main/packages/com.sonosthesia.pack) so that remote tri-band and quint-band streams can be received or generated inside Unity.
+
+## Band splitters
+
+`AudioTriBandSplitter` and `AudioQuintBandSplitter` take spectral analysis and expose float signals for each band. They follow the same addressing scheme as the pack protocol (`/audio/tribands` and `/audio/quintbands`) so the data can be forwarded over WebSocket or stored alongside other packed messages.
+
+## Receivers and signals
+
+`PackAudioTriBandReceiver` and `PackAudioQuintBandReceiver` listen for incoming pack messages and reconstitute them as Unity signals. `AudioBandFloatSignal` and `AudioQuintBandFloatSignal` make the band values available to other signal-aware components without having to parse message payloads manually.


### PR DESCRIPTION
## Summary
- expand README coverage for the arpeggiator channel utilities
- document FMOD core helpers and FMOD interaction affordances
- add basic guidance for packaudio and deforminteraction modules

## Testing
- not run (documentation-only)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69272cd75ccc8331a7774d38b0d7ce59)